### PR TITLE
disable soundtrack on archive pages & improve UX of disabled play buttons

### DIFF
--- a/wp-content/plugins/audioblocks/audioblocks.php
+++ b/wp-content/plugins/audioblocks/audioblocks.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Page Soundtrack Blocks
-Version: 0.0.2
+Version: 0.0.4
 Plugin URI: https://github.com/haszari/wcbne-audio-blocks/
 Description: Add a dynamic bpm-synched soundtrack to your pages or posts.
 Author: haszari@cartoonbeats.com

--- a/wp-content/plugins/audioblocks/audioblocks.php
+++ b/wp-content/plugins/audioblocks/audioblocks.php
@@ -81,6 +81,12 @@ add_action( 'init', 'pagesoundtrack_blocks_init' );
 
 // Render our page tempo value so we can use it in our front-end script.
 function pagesoundtrack_blocks_content_filter( $content ) {
+	if ( ! is_single() ) {
+		// Only render tempo element for single-post pages, to disable soundtrack on
+		// archives etc.
+		return $content;
+	}
+
     $value = get_post_meta( get_the_ID(), 'pagesoundtrack_playbackbpm', true );
     if ( $value ) {
     	$cleaned = esc_html( $value );

--- a/wp-content/plugins/audioblocks/package.json
+++ b/wp-content/plugins/audioblocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cbr/pagesoundtrack",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/wp-content/plugins/audioblocks/src/frontend.js
+++ b/wp-content/plugins/audioblocks/src/frontend.js
@@ -25,7 +25,7 @@ const pageState = {
 	loopers: [],
 	playButtons: [],
 	isPlaying: false,
-	playbackTempo: 120,
+	playbackTempo: 0,
 }
 
 function onScrollChange() {
@@ -77,15 +77,15 @@ function togglePlayback() {
 	} );
 }
 
-function disablePlayButtons() {
+function disablePlayButtons( label, tooltip ) {
 	pageState.playButtons = getPlayButtonElements();
 
 	pageState.playButtons.forEach( playButton => {
 		playButton.disabled = true;
-		playButton.textContent = 'Loading'
+		playButton.textContent = label;
+		playButton.title = tooltip;
 	} );
 }
-
 
 function setupPlayButtons() {
 	pageState.playButtons = getPlayButtonElements();
@@ -98,7 +98,7 @@ function setupPlayButtons() {
 }
 
 function getPageTempo() {
-	let tempo = 120;
+	let tempo = 0;
 
 	const pageTempoMetaElement = document.querySelector( '#page-soundtrack-tempo' );
 	if ( ! pageTempoMetaElement ) {
@@ -113,11 +113,19 @@ function getPageTempo() {
 }
 
 function setupPageSoundtrack() {
-	disablePlayButtons();
+	disablePlayButtons( 'Soundtrack disabled', 'Page soundtrack is disabled on multi-post pages. View full post to play soundtrack.' );
 
 	const allLoops = getLoopElements();
 
 	pageState.playbackTempo = getPageTempo();
+
+	// Leave everything disabled if tempo is not available.
+	// This is used to disable soundtrack on archive / multi post pages.
+	if ( pageState.playbackTempo < 1 ) {
+		return;
+	}
+
+	disablePlayButtons( 'Loading', 'Loading audio files for page soundtrack…' );
 
 	const loopersProps = allLoops.map( element => {
 		return {

--- a/wp-content/plugins/audioblocks/src/style/frontend.css
+++ b/wp-content/plugins/audioblocks/src/style/frontend.css
@@ -13,6 +13,16 @@ body {
 	margin: 1em 0;
 }
 
+.wp-block-soundtrack-playbutton button[disabled] {
+	background-color: lightgray;
+	font-size: 50%;
+	cursor: default;
+}
+
+.wp-block-soundtrack-playbutton button[disabled]:hover {
+	text-decoration: none;
+}
+
 .wp-block-soundtrack-loop .audioLoopCard {
 	background: var(--page-soundtrack-bg-color);
 	color: var(--page-soundtrack-fg-color);


### PR DESCRIPTION
Fixes #29 

This PR disables page soundtrack features when viewing the post in a list, archive, or anywhere other than the individual post page.

The soundtrack blocks assume a single page tempo, so for now it's simplest to disable so this assumption is held.

This PR also adds some disabled styles for the play button, so when the soundtrack is disabled, the user is informed that they need to click through to the post page to hear things.