### PR TITLE
fix soundtrack on pages

### DIFF
--- a/wp-content/plugins/audioblocks/audioblocks.php
+++ b/wp-content/plugins/audioblocks/audioblocks.php
@@ -71,17 +71,21 @@ add_action( 'enqueue_block_editor_assets', 'pagesoundtrack_enqueue_block_editor_
 // Register a meta field that our blocks depend on.
 // It needs to be exposed to REST API so the value is available in Gutenberg environment.
 function pagesoundtrack_blocks_init() {
-    register_post_meta( 'post', 'pagesoundtrack_playbackbpm', array(
-        'show_in_rest' => true,
-        'single' => true,
-        'type' => 'number',
-    ) );
+    register_post_meta(
+    	'', // Register for all post types - posts and pages.
+    	'pagesoundtrack_playbackbpm',
+    	array(
+	        'show_in_rest' => true,
+	        'single' => true,
+	        'type' => 'number',
+	    )
+    );
 }
 add_action( 'init', 'pagesoundtrack_blocks_init' );
 
 // Render our page tempo value so we can use it in our front-end script.
 function pagesoundtrack_blocks_content_filter( $content ) {
-	if ( ! is_single() ) {
+	if ( ! is_singular() ) {
 		// Only render tempo element for single-post pages, to disable soundtrack on
 		// archives etc.
 		return $content;


### PR DESCRIPTION
The soundtrack was not working on page content type.

There were two issues:

- The custom meta field (for page tempo) was only registered for (blog) post content type.
- The new code to limit to non-archive pages was limiting to single blog post only. 

This PR fixes both of those so soundtrack can be used on any "single" page for any post type, typically posts and pages.